### PR TITLE
make "get roster" command work with recent clients

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -208,7 +208,7 @@ int i;
 	xmlnode_put_attrib(msg,"to",s->user->jid);
 	n=xmlnode_insert_tag(msg,"body");
 	roster=xmlnode_insert_tag(msg,"x");
-	xmlnode_put_attrib(roster,"xmlns","jabber:x:roster");
+	xmlnode_put_attrib(roster,"xmlns","http://jabber.org/protocol/rosterx");
 
 	body=g_strdup("");
 	results=g_strsplit(e->event.userlist.reply,"\r\n",0);
@@ -281,6 +281,7 @@ int i;
 		}
 
 		jid=jid_build(uin);
+		xmlnode_put_attrib(item,"action", "add");
 		xmlnode_put_attrib(item,"jid",jid);
 		g_free(jid);
 		if (name==NULL) name=g_strdup_printf("%u",uin);


### PR DESCRIPTION
xep 0093: http://xmpp.org/extensions/xep-0093.html
xep 0144: http://xmpp.org/extensions/xep-0144.html

basicaly, they differ with namespace and new action attribute for <item>
element. (also, xep 0093 does not work with psi, xep 0144 does.)

Tested with psi 0.15 and prosody 0.8.2.
